### PR TITLE
Update to Intel's 2.26.8

### DIFF
--- a/SOURCES/intel-i40e-2.22.20.tar.gz
+++ b/SOURCES/intel-i40e-2.22.20.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:f7553d86e022a71a5c142cc5d4b7ba20c9797bcd5a2f8cc40b5f72b17b33883d
-size 698572

--- a/SOURCES/intel-i40e-2.26.8.tar.gz
+++ b/SOURCES/intel-i40e-2.26.8.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:3353ac8549fa9a665d66d46ba091976e1e522e4e59e5fd6dd9ad9b105f753a49
+size 3604480

--- a/SPECS/intel-i40e-alt.spec
+++ b/SPECS/intel-i40e-alt.spec
@@ -1,5 +1,3 @@
-%global xsver 3
-%global xsrel %{xsver}%{?xscount}%{?xshash}
 %define vendor_name Intel
 %define vendor_label intel
 %define driver_name i40e
@@ -16,10 +14,10 @@
 
 Summary: %{vendor_name} %{driver_name} device drivers
 Name: %{vendor_label}-%{driver_name}-alt
-Version: 2.22.20
-Release: %{?xsrel}.1%{?dist}
+Version: 2.26.8
+Release: 1%{?dist}
 License: GPL
-Source0: intel-i40e-2.22.20.tar.gz
+Source0: intel-i40e-%{version}.tar.gz
 Patch0: disable-fw-lldp-by-default.patch
 Patch1: fix-memory-leak-and-other-bugs.patch
 
@@ -41,7 +39,7 @@ version %{kernel_version}.
 cd src
 KSRC=/lib/modules/%{kernel_version}/build OUT=kcompat_generated_defs.h CONFFILE=/lib/modules/%{kernel_version}/build/.config bash kcompat-generator.sh
 cd ..
-%{make_build} -C /lib/modules/%{kernel_version}/build M=$(pwd)/src KSRC=/lib/modules/%{kernel_version}/build NEED_AUX_BUS=2 modules
+%{make_build} -C /lib/modules/%{kernel_version}/build M=$(pwd)/src KSRC=/lib/modules/%{kernel_version}/build modules
 
 %install
 %{__make} %{?_smp_mflags} -C /lib/modules/%{kernel_version}/build M=$(pwd)/src INSTALL_MOD_PATH=%{buildroot} INSTALL_MOD_DIR=%{module_dir} DEPMOD=/bin/true modules_install
@@ -64,6 +62,12 @@ find %{buildroot}/lib/modules/%{kernel_version} -name "*.ko" -type f | xargs chm
 /lib/modules/%{kernel_version}/*/*.ko
 
 %changelog
+* Fri Nov 15 2024 David Morel <david.morel@vates.tech> - 2.26.8-1
+- Update from Intel's latest driver 2.26.8
+- NEED_AUX_BUS=2 compiles auxiliary bus code within the driver, but our kernel
+  already provides it. This leads to redefinition of AUXILIARY_MODULE_PREFIX,
+  so remove it to make the driver compile.
+
 * Mon Aug 21 2023 Gael Duperrey <gduperrey@vates.fr> - 2.22.20-3.1
 - initial package, version 2.22.20-3.1
 - Synced from XS driver SRPM intel-i40e-2.22.20-3.xs8~2_1.src.rpm


### PR DESCRIPTION
- Move to intel latest version
- Fix build by disabling auxiliary informations detection